### PR TITLE
Fix Plovdiv spelling in site description

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   output-dir: docs
 
 website:
-  description: Kostadin Kostadinov | Assistant Professor at the Medical University of Plodiv
+  description: Kostadin Kostadinov | Assistant Professor at the Medical University of Plovdiv
 
   page-footer:
     left: "Email me at <a href='mailto:kostadinr.kostadinov@mu-plovdiv.bg'>kostadinr.kostadinov@mu-plovdiv.bg</a> or book a <a href='https://tinyurl.com/whentomeetme' target='_blank'>meeting</a>"


### PR DESCRIPTION
## Summary
- fix spelling of Plovdiv in the site description

## Testing
- `quarto check` *(fails: command not found)*
- `apt-get update && apt-get install -y quarto` *(fails: repository 403, unable to locate package)*
- `python - <<'PY' ...` *(fails: No module named 'yaml'; `pip install pyyaml` fails due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68970c06dfc88323aef5b0dd3f5029b6